### PR TITLE
Use package prefix

### DIFF
--- a/R/hatenab.R
+++ b/R/hatenab.R
@@ -7,7 +7,7 @@ getBookmarkCount <- function(url){
                 paste(collapse="&", paste0("url=",url))
     )
     res <- GET(u)
-    res <- content(res)
+    res <- httr::content(res)
   } else{
     loops <- trunc(counts/50)+1
     res <- NULL
@@ -18,7 +18,7 @@ getBookmarkCount <- function(url){
                   paste(collapse="&", paste0("url=",url0))
       )
       res0 <- GET(u)
-      res <- c(res, content(res0))
+      res <- c(res, httr::content(res0))
       Sys.sleep(0.5)
     }
    }


### PR DESCRIPTION
Avoid to conflict with `{NLP}` namespace.

```
library(NLP)
content
# function (x) 
# UseMethod("content", x)
# <environment: namespace:NLP>
```
